### PR TITLE
Displaybufferex indexed8 fixes

### DIFF
--- a/esphome/components/display/bufferex_1bit_2color.cpp
+++ b/esphome/components/display/bufferex_1bit_2color.cpp
@@ -22,10 +22,10 @@ void Bufferex1bit2color::fill_buffer(Color color) {
   memset(this->buffer_, color.r + color.b + color.g == 0 ? 0 : 1, this->get_buffer_size());
 }
 
-uint16_t Bufferex1bit2color::get_pixel_buffer_position_internal_(int x, int y) { return (x + y * this->width_); }
+uint32_t Bufferex1bit2color::get_pixel_buffer_position_internal_(int x, int y) { return (x + y * this->width_); }
 
 void HOT Bufferex1bit2color::set_buffer(int x, int y, Color color) {
-  const uint16_t byte_location = get_pixel_buffer_position_internal_(x, y) / 8;
+  const uint32_t byte_location = get_pixel_buffer_position_internal_(x, y) / 8;
   const uint8_t byte_offset = get_pixel_buffer_position_internal_(x, y) - (byte_location * 8);
 
   uint8_t color_byte = this->buffer_[byte_location];
@@ -34,7 +34,7 @@ void HOT Bufferex1bit2color::set_buffer(int x, int y, Color color) {
 }
 
 uint8_t Bufferex1bit2color::get_color_bit_(int x, int y) {
-  const uint16_t byte_location = get_pixel_buffer_position_internal_(x, y) / 8;
+  const uint32_t byte_location = get_pixel_buffer_position_internal_(x, y) / 8;
   const uint8_t byte_offset = get_pixel_buffer_position_internal_(x, y) - (byte_location * 8);
 
   auto color_byte = this->buffer_[byte_location];
@@ -42,8 +42,8 @@ uint8_t Bufferex1bit2color::get_color_bit_(int x, int y) {
   return color_bit;
 }
 
-uint8_t Bufferex1bit2color::get_color_bit_(uint16_t pos) {
-  const uint16_t byte_location = pos / 8;
+uint8_t Bufferex1bit2color::get_color_bit_(uint32_t pos) {
+  const uint32_t byte_location = pos / 8;
   const uint8_t byte_offset = pos - (byte_location * 8);
 
   auto color_byte = this->buffer_[byte_location];
@@ -60,7 +60,7 @@ uint16_t Bufferex1bit2color::get_pixel_to_565(int x, int y) {
   return this->color_on_.to_565();
 }
 
-uint16_t Bufferex1bit2color::get_pixel_to_565(uint16_t pos) {
+uint16_t Bufferex1bit2color::get_pixel_to_565(uint32_t pos) {
   uint8_t color_bit = this->get_color_bit_(pos);
 
   if (color_bit == 0)
@@ -78,7 +78,7 @@ uint32_t Bufferex1bit2color::get_pixel_to_666(int x, int y) {
   return this->color_on_.to_666();
 }
 
-uint32_t Bufferex1bit2color::get_pixel_to_666(uint16_t pos) {
+uint32_t Bufferex1bit2color::get_pixel_to_666(uint32_t pos) {
   uint8_t color_bit = this->get_color_bit_(pos);
 
   if (color_bit == 0)

--- a/esphome/components/display/bufferex_1bit_2color.h
+++ b/esphome/components/display/bufferex_1bit_2color.h
@@ -12,9 +12,9 @@ class Bufferex1bit2color : public display::BufferexBase {
   void set_buffer(int x, int y, Color color) override;
   void fill_buffer(Color color) override;
   uint16_t get_pixel_to_565(int x, int y) override;
-  uint16_t get_pixel_to_565(uint16_t pos) override;
+  uint16_t get_pixel_to_565(uint32_t pos) override;
   uint32_t get_pixel_to_666(int x, int y) override;
-  uint32_t get_pixel_to_666(uint16_t pos) override;
+  uint32_t get_pixel_to_666(uint32_t pos) override;
   size_t get_buffer_length() override;
   size_t get_buffer_size() override;
 
@@ -24,10 +24,10 @@ class Bufferex1bit2color : public display::BufferexBase {
  protected:
   Color color_on_ = COLOR_WHITE;
   Color color_off_ = COLOR_BLACK;
-  uint16_t get_pixel_buffer_position_internal_(int x, int y);
+  uint32_t get_pixel_buffer_position_internal_(int x, int y);
 
   uint8_t get_color_bit_(int x, int y);
-  uint8_t get_color_bit_(uint16_t pos);
+  uint8_t get_color_bit_(uint32_t pos);
   display::BufferType get_buffer_type() override { return this->buffer_type_; }
   uint8_t get_pixel_storage_size() override { return this->pixel_storage_size_; }
 

--- a/esphome/components/display/bufferex_332.cpp
+++ b/esphome/components/display/bufferex_332.cpp
@@ -25,7 +25,7 @@ void Bufferex332::fill_buffer(Color color) {
 }
 
 void HOT Bufferex332::set_buffer(int x, int y, Color color) {
-  uint16_t pos = get_pixel_buffer_position_(x, y);
+  uint32_t pos = get_pixel_buffer_position_(x, y);
   const uint16_t color332 = color.to_332();
   this->buffer_[pos] = color332;
 }
@@ -33,13 +33,13 @@ void HOT Bufferex332::set_buffer(int x, int y, Color color) {
 size_t Bufferex332::get_buffer_size() { return this->get_buffer_length(); }
 
 // 565
-uint16_t Bufferex332::get_pixel_to_565(uint16_t pos) {
+uint16_t Bufferex332::get_pixel_to_565(uint32_t pos) {
   return Color(this->buffer_[pos], Color::ColorOrder::COLOR_ORDER_RGB, Color::ColorBitness::COLOR_BITNESS_332, true)
       .to_565();
 }
 
 // 666
-uint32_t Bufferex332::get_pixel_to_666(uint16_t pos) {
+uint32_t Bufferex332::get_pixel_to_666(uint32_t pos) {
   return Color(this->buffer_[pos], Color::ColorOrder::COLOR_ORDER_RGB, Color::ColorBitness::COLOR_BITNESS_565, true)
       .to_666();
 }

--- a/esphome/components/display/bufferex_332.h
+++ b/esphome/components/display/bufferex_332.h
@@ -11,8 +11,8 @@ class Bufferex332 : public display::BufferexBase {
   void init_buffer(int width, int height) override;
   void set_buffer(int x, int y, Color color) override;
   void fill_buffer(Color color) override;
-  uint16_t get_pixel_to_565(uint16_t pos) override;
-  uint32_t get_pixel_to_666(uint16_t pos) override;
+  uint16_t get_pixel_to_565(uint32_t pos) override;
+  uint32_t get_pixel_to_666(uint32_t pos) override;
   size_t get_buffer_size() override;
   display::BufferType get_buffer_type() override { return this->buffer_type_; }
   uint8_t get_pixel_storage_size() override { return this->pixel_storage_size_; }

--- a/esphome/components/display/bufferex_565.cpp
+++ b/esphome/components/display/bufferex_565.cpp
@@ -28,15 +28,15 @@ size_t Bufferex565::get_buffer_size() { return this->get_buffer_length() * 2; }
 
 void HOT Bufferex565::set_buffer(int x, int y, Color color) {
   const uint16_t color565 = color.to_565();
-  uint16_t pos = get_pixel_buffer_position_(x, y);
+  uint32_t pos = get_pixel_buffer_position_(x, y);
   this->buffer_[pos] = color565;
 }
 
 // 565
-uint16_t Bufferex565::get_pixel_to_565(uint16_t pos) { return this->buffer_[pos]; }
+uint16_t Bufferex565::get_pixel_to_565(uint32_t pos) { return this->buffer_[pos]; }
 
 // 666
-uint32_t Bufferex565::get_pixel_to_666(uint16_t pos) {
+uint32_t Bufferex565::get_pixel_to_666(uint32_t pos) {
   return Color(this->buffer_[pos], Color::ColorOrder::COLOR_ORDER_RGB, Color::ColorBitness::COLOR_BITNESS_565, true)
       .to_666();
 }

--- a/esphome/components/display/bufferex_565.h
+++ b/esphome/components/display/bufferex_565.h
@@ -11,8 +11,8 @@ class Bufferex565 : public display::BufferexBase {
   void init_buffer(int width, int height) override;
   void set_buffer(int x, int y, Color color) override;
   void fill_buffer(Color color) override;
-  uint16_t get_pixel_to_565(uint16_t pos) override;
-  uint32_t get_pixel_to_666(uint16_t pos) override;
+  uint16_t get_pixel_to_565(uint32_t pos) override;
+  uint32_t get_pixel_to_666(uint32_t pos) override;
   size_t get_buffer_size() override;
 
   display::BufferType get_buffer_type() override { return this->buffer_type_; }

--- a/esphome/components/display/bufferex_666.cpp
+++ b/esphome/components/display/bufferex_666.cpp
@@ -26,7 +26,7 @@ void Bufferex666::fill_buffer(Color color) {
 size_t Bufferex666::get_buffer_size() { return this->get_buffer_length() * 4; }
 
 void HOT Bufferex666::set_buffer(int x, int y, Color color) {
-  uint16_t pos = get_pixel_buffer_position_(x, y);
+  uint32_t pos = get_pixel_buffer_position_(x, y);
   const uint32_t color666 = color.to_666(this->driver_right_bit_aligned_);
   // if (y == 0) {
   //   ESP_LOGD(TAG, "set_buffer color666 %d", color666);
@@ -35,14 +35,14 @@ void HOT Bufferex666::set_buffer(int x, int y, Color color) {
 }
 
 // 565
-uint16_t Bufferex666::get_pixel_to_565(uint16_t pos) {
+uint16_t Bufferex666::get_pixel_to_565(uint32_t pos) {
   return Color(this->buffer_[pos], Color::ColorOrder::COLOR_ORDER_RGB, Color::ColorBitness::COLOR_BITNESS_666,
                this->driver_right_bit_aligned_)
       .to_565();
 }
 
 // 666
-uint32_t Bufferex666::get_pixel_to_666(uint16_t pos) { return this->buffer_[pos]; }
+uint32_t Bufferex666::get_pixel_to_666(uint32_t pos) { return this->buffer_[pos]; }
 
 }  // namespace display
 }  // namespace esphome

--- a/esphome/components/display/bufferex_666.h
+++ b/esphome/components/display/bufferex_666.h
@@ -11,8 +11,8 @@ class Bufferex666 : public display::BufferexBase {
   void init_buffer(int width, int height) override;
   void set_buffer(int x, int y, Color color) override;
   void fill_buffer(Color color) override;
-  uint16_t get_pixel_to_565(uint16_t pos) override;
-  uint32_t get_pixel_to_666(uint16_t pos) override;
+  uint16_t get_pixel_to_565(uint32_t pos) override;
+  uint32_t get_pixel_to_666(uint32_t pos) override;
   size_t get_buffer_size() override;
   display::BufferType get_buffer_type() override { return this->buffer_type_; }
   uint8_t get_pixel_storage_size() override { return this->pixel_storage_size_; }

--- a/esphome/components/display/bufferex_base.h
+++ b/esphome/components/display/bufferex_base.h
@@ -21,17 +21,17 @@ class BufferexBase {
 
   // 565
   virtual uint16_t get_pixel_to_565(int x, int y) {
-    const uint16_t pos = get_pixel_buffer_position_(x, y);
+    const uint32_t pos = get_pixel_buffer_position_(x, y);
     return this->get_pixel_to_565(pos);
   }
-  virtual uint16_t get_pixel_to_565(uint16_t pos) = 0;
+  virtual uint16_t get_pixel_to_565(uint32_t pos) = 0;
 
   // 666
   virtual uint32_t get_pixel_to_666(int x, int y) {
-    const uint16_t pos = get_pixel_buffer_position_(x, y);
+    const uint32_t pos = get_pixel_buffer_position_(x, y);
     return this->get_pixel_to_666(pos);
   };
-  virtual uint32_t get_pixel_to_666(uint16_t pos) = 0;
+  virtual uint32_t get_pixel_to_666(uint32_t pos) = 0;
 
   virtual size_t get_buffer_size() = 0;
   virtual size_t get_buffer_length();
@@ -55,7 +55,7 @@ class BufferexBase {
  protected:
   int16_t width_ = 0, height_ = 0;
   bool driver_right_bit_aligned_ = false;
-  uint16_t get_pixel_buffer_position_(int x, int y) { return (x + y * width_); }
+  uint32_t get_pixel_buffer_position_(int x, int y) { return (x + y * width_); }
   std::vector<Color> colors_;
 };  // class BufferexBase
 }  // namespace display

--- a/esphome/components/display/bufferex_indexed8.cpp
+++ b/esphome/components/display/bufferex_indexed8.cpp
@@ -92,7 +92,7 @@ uint8_t HOT BufferexIndexed8::get_index_value_(uint32_t pos) {
 
   uint8_t index_byte_start = this->buffer_[byte_location_start];
   const uint8_t byte_offset_start = pixel_bit_start % 8;
-  
+
   uint8_t mask = (1 << this->pixel_storage_size_) - 1;
 
   index_byte_start = (index_byte_start >> byte_offset_start);
@@ -101,7 +101,7 @@ uint8_t HOT BufferexIndexed8::get_index_value_(uint32_t pos) {
     // Pixel starts and ends in the same byte, so we're done.
     return index_byte_start & mask;
   }
-  
+
   const uint8_t byte_offset_end = pixel_bit_end % 8;
 
   uint8_t end_mask = mask >> (this->pixel_storage_size_ - byte_offset_end);

--- a/esphome/components/display/bufferex_indexed8.cpp
+++ b/esphome/components/display/bufferex_indexed8.cpp
@@ -41,7 +41,7 @@ void BufferexIndexed8::fill_buffer(Color color) {
 }
 
 void HOT BufferexIndexed8::set_buffer(int x, int y, Color color) {
-  uint16_t pos = (x + y * this->width_);
+  uint32_t pos = (x + y * this->width_);
   bool debug = false;
 
   uint8_t index = 0;
@@ -52,11 +52,11 @@ void HOT BufferexIndexed8::set_buffer(int x, int y, Color color) {
     }
   }
 
-  const uint16_t pixel_bit_start = pos * this->pixel_storage_size_;
-  const uint16_t pixel_bit_end = pixel_bit_start + this->pixel_storage_size_;
+  const uint32_t pixel_bit_start = pos * this->pixel_storage_size_;
+  const uint32_t pixel_bit_end = pixel_bit_start + this->pixel_storage_size_;
 
-  const uint16_t byte_location_start = pixel_bit_start / 8;
-  const uint16_t byte_location_end = pixel_bit_end / 8;
+  const uint32_t byte_location_start = pixel_bit_start / 8;
+  const uint32_t byte_location_end = pixel_bit_end / 8;
 
   const uint8_t byte_offset_start = pixel_bit_start - (byte_location_start * 8);
   uint8_t index_byte_start = this->buffer_[byte_location_start];
@@ -81,12 +81,12 @@ void HOT BufferexIndexed8::set_buffer(int x, int y, Color color) {
 
 uint8_t HOT BufferexIndexed8::get_index_value_(int x, int y) { return this->get_index_value_((x + y * this->width_)); }
 
-uint8_t HOT BufferexIndexed8::get_index_value_(uint16_t pos) {
-  const uint16_t pixel_bit_start = pos * this->pixel_storage_size_;
-  const uint16_t pixel_bit_end = pixel_bit_start + this->pixel_storage_size_;
+uint8_t HOT BufferexIndexed8::get_index_value_(uint32_t pos) {
+  const uint32_t pixel_bit_start = pos * this->pixel_storage_size_;
+  const uint32_t pixel_bit_end = pixel_bit_start + this->pixel_storage_size_;
 
-  const uint16_t byte_location_start = pixel_bit_start / 8;
-  const uint16_t byte_location_end = pixel_bit_end / 8;
+  const uint32_t byte_location_start = pixel_bit_start / 8;
+  const uint32_t byte_location_end = pixel_bit_end / 8;
 
   uint8_t index_byte_start = this->buffer_[byte_location_start];
   const uint8_t byte_offset_start = pixel_bit_start - (byte_location_start * 8);
@@ -120,7 +120,7 @@ uint16_t BufferexIndexed8::get_pixel_to_565(int x, int y) {
   return this->colors_[value].to_565(this->driver_right_bit_aligned_);
 }
 
-uint16_t BufferexIndexed8::get_pixel_to_565(uint16_t pos) {
+uint16_t BufferexIndexed8::get_pixel_to_565(uint32_t pos) {
   uint8_t value = this->get_index_value_(pos);
 
   if (value > this->index_size_)
@@ -141,7 +141,7 @@ uint32_t HOT BufferexIndexed8::get_pixel_to_666(int x, int y) {
   return this->colors_[value].to_666(this->driver_right_bit_aligned_);
 }
 
-uint32_t HOT BufferexIndexed8::get_pixel_to_666(uint16_t pos) {
+uint32_t HOT BufferexIndexed8::get_pixel_to_666(uint32_t pos) {
   uint8_t value = this->get_index_value_(pos);
 
   if (value > this->index_size_)

--- a/esphome/components/display/bufferex_indexed8.h
+++ b/esphome/components/display/bufferex_indexed8.h
@@ -13,9 +13,9 @@ class BufferexIndexed8 : public display::BufferexBase {
 
   void fill_buffer(Color color) override;
   uint16_t get_pixel_to_565(int x, int y) override;
-  uint16_t get_pixel_to_565(uint16_t pos) override;
+  uint16_t get_pixel_to_565(uint32_t pos) override;
   uint32_t get_pixel_to_666(int x, int y) override;
-  uint32_t get_pixel_to_666(uint16_t pos) override;
+  uint32_t get_pixel_to_666(uint32_t pos) override;
   size_t get_buffer_length() override;
   size_t get_buffer_size() override;
   void set_index_size(uint8_t index_size) { this->index_size_ = index_size; }
@@ -29,7 +29,7 @@ class BufferexIndexed8 : public display::BufferexBase {
   size_t get_buffer_length_ = 0;
 
   uint8_t get_index_value_(int x, int y);
-  uint8_t get_index_value_(uint16_t pos);
+  uint8_t get_index_value_(uint32_t pos);
   display::BufferType get_buffer_type() override { return this->buffer_type_; }
   uint8_t get_pixel_storage_size() override { return this->pixel_storage_size_; }
 


### PR DESCRIPTION
## Description:
- Bumps the pixel index (`pos`) to uint32_t to avoid unreasonably constraining display size
- Fixes / optimises indexed8 buffer setting and getting

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
